### PR TITLE
Makes our license valid + includes others

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,28 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
------
-
-Included code for BIP32-compatible hierarchical deterministic wallet is also licensed under the
-MIT license:
-
-Copyright (c) 2011-2018 bitcoinjs-lib contributors
-
------
-
-Included code for ed25519 keypairs is licensed under the Apache license:
-
-Copyright 2015 Stellar Development Foundation
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-limitations under the License.

--- a/OPEN_SOURCE.md
+++ b/OPEN_SOURCE.md
@@ -1,0 +1,26 @@
+# Open Source Licenses
+
+-----
+
+Included code for BIP32-compatible hierarchical deterministic wallet
+licensed under the MIT license:
+
+Copyright (c) 2011-2018 bitcoinjs-lib contributors
+
+-----
+
+Included code for ed25519 keypairs is licensed under the Apache license:
+
+Copyright 2015 Stellar Development Foundation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
Our license wasn't registering properly on github, making it _slightly_ harder to grock what it is on first glance. This should fix that. But it also makes sure to include the licenses for some code we ported. Not sure if this is a 'normal' thing to do or not? @andrewxhill do you have any thoughts here?