### PR TITLE
moves feed.get to feed.list

### DIFF
--- a/src/modules/__test__/feed.test.ts
+++ b/src/modules/__test__/feed.test.ts
@@ -18,7 +18,7 @@ describe('feed get stacked', () => {
       .get('/api/v0/feed')
       .reply(200, stacks)
 
-    expect(await feed.get(undefined, undefined, 5, 'stacks')).toEqual(stacks)
+    expect(await feed.list(undefined, undefined, 5, 'stacks')).toEqual(stacks)
   })
 })
 
@@ -28,6 +28,6 @@ describe('feed get chrono (default)', () => {
       .get('/api/v0/feed')
       .reply(200, chrono)
 
-    expect(await feed.get()).toEqual(chrono)
+    expect(await feed.list()).toEqual(chrono)
   })
 })

--- a/src/modules/feed.ts
+++ b/src/modules/feed.ts
@@ -31,7 +31,7 @@ export default class Feed extends API {
    * @param limit List page size (default: 5)
    * @param mode Feed mode (one of 'chrono’, 'annotated’, or ‘stacks’)
    */
-  async get(thread?: string, offset?: string, limit?: number, mode?: FeedModes) {
+  async list(thread?: string, offset?: string, limit?: number, mode?: FeedModes) {
     const response = await this.sendGet(
       'feed',
       undefined,


### PR DESCRIPTION
fixes: https://github.com/textileio/js-http-client/issues/96