### PR TITLE
CI only on master + github release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,8 +67,6 @@ workflows:
                 filters:
                     tags:
                         only: /.*/
-                    branches:
-                        only: master
             - deploy:
                 requires:
                     - lint-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -66,7 +66,7 @@ workflows:
             - lint-test:
                 filters:
                     tags:
-                        only: /^v.*/
+                        only: /.*/
                     branches:
                         only: master
             - deploy:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
                 key: node-v1-{{ checksum "package.json" }}-{{ arch }}
             - run: yarn install
             - run:
-                name: lint
+                name: Lint
                 command: |
                     yarn lint
             - save_cache:
@@ -28,7 +28,7 @@ jobs:
                 paths:
                     - node_modules
             - run:
-                name: test
+                name: Test
                 command: |
                     mkdir -p test-results/jest
                     yarn test
@@ -50,11 +50,14 @@ jobs:
             - attach_workspace:
                 at: ~/js-http-client
             - run:
-                name: Authenticate with registry
+                name: Authenticate
                 command: echo "//registry.npmjs.org/:_authToken=$NPM_TOKEN" > ~/js-http-client/.npmrc
             - run:
-                name: Publish package
+                name: Publish Package
                 command: npm publish --access=public --dry-run --unsafe-perm
+            - run:
+                name: Create Release
+                command: ghr -t ${GITHUB_TOKEN} -u ${CIRCLE_PROJECT_USERNAME} -r ${CIRCLE_PROJECT_REPONAME} -c ${CIRCLE_SHA1} -delete ${CIRCLE_TAG}
                         
 workflows:
     version: 2
@@ -64,6 +67,8 @@ workflows:
                 filters:
                     tags:
                         only: /^v.*/
+                    branches:
+                        only: master
             - deploy:
                 requires:
                     - lint-test


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

This should filter on master branch, and should do a proper github release when we actually deploy from CI.