### PR TITLE
Support arbitrary binary data in file add API

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,8 @@
   "author": "textile.io",
   "license": "MIT",
   "dependencies": {
-    "isomorphic-fetch": "^2.2.1",
+    "@softwareventures/fetch-ponyfill-preconfigured": "^1.1.0",
+    "isomorphic-form-data": "^2.0.0",
     "toposort": "^2.0.2",
     "url-parse": "^1.4.4",
     "url-toolkit": "^2.1.6",
@@ -48,7 +49,6 @@
   },
   "devDependencies": {
     "@textile/tslint-rules": "1.0.3",
-    "@types/isomorphic-fetch": "^0.0.35",
     "@types/jest": "^24.0.11",
     "@types/nock": "^9.3.1",
     "@types/toposort": "^2.0.1",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -1,4 +1,5 @@
-import fetch from 'isomorphic-fetch'
+import { fetch, Headers } from '@softwareventures/fetch-ponyfill-preconfigured'
+import FormData from 'isomorphic-form-data'
 import URL from 'url-parse'
 import { buildAbsoluteURL } from 'url-toolkit'
 import { KeyValue, ApiOptions } from '../models'
@@ -103,32 +104,12 @@ class API {
    * @param opts An object of options to pass as Textile options headers
    * @param data An object of data to post
    */
-  protected async sendPost(url: string, args?: string[], opts?: KeyValue, data?: any, headers?: KeyValue) {
-    const response = await fetch(buildAbsoluteURL(this.baseURL, url), {
-      method: 'POST',
-      headers: createHeaders(args, opts, headers),
-      body: JSON.stringify(data)
-    })
-    return handleErrors(response)
-  }
-
-  /**
-   * Make a post request to the Textile node using a multi-part form
-   *
-   * @param url The relative URL of the API endpoint
-   * @param args An array of arguments to pass as Textile args headers
-   * @param opts An object of options to pass as Textile options headers
-   * @param data An object of data to post
-   */
-  protected async sendPostMultiPart(url: string, args?: string[], opts?: KeyValue, data?: any, headers?: KeyValue) {
+  protected async sendPost(url: string, args?: string[], opts?: KeyValue, data?: any, headers?: KeyValue, raw?: boolean) {
     const h = createHeaders(args, opts, headers)
-    // Remove 'Content-Type' header to allow fetch to add along with the correct 'boundary'
-    delete h['content-type']
-    delete h['Content-Type'] // TODO: Find nicer way to do this
     const response = await fetch(buildAbsoluteURL(this.baseURL, url), {
       method: 'POST',
       headers: new Headers(h),
-      body: data
+      body: raw ? data : JSON.stringify(data)
     })
     return handleErrors(response)
   }

--- a/src/core/isomorphic-form-data.d.ts
+++ b/src/core/isomorphic-form-data.d.ts
@@ -1,0 +1,8 @@
+// For the purposes of js-http-client development, this is the minimal
+// required interface to support FormData in Nodejs an browsers
+
+declare module 'isomorphic-form-data' {
+  export default class FormData {
+    append(key: string, value: File, filename?: string): void
+  }
+}

--- a/src/modules/file.ts
+++ b/src/modules/file.ts
@@ -11,11 +11,11 @@ export default class File extends API {
    *
    * Get raw data for a File
    *
-   * @param file File object
+   * @param hash The hash for the requested file
    * @returns Raw data
    */
-  async content(hash: string): Promise<string> {
+  async content(hash: string) {
     const response = await this.sendGet(`file/${hash}/data`)
-    return response.text() as Promise<string>
+    return response.blob()
   }
 }

--- a/src/modules/mills.ts
+++ b/src/modules/mills.ts
@@ -1,5 +1,6 @@
 import { API } from '../core/api'
 import { KeyValue, FileIndex } from '../models'
+import FormData from 'isomorphic-form-data'
 
 /**
  * Mills is an API module for processing Textile mills
@@ -24,13 +25,22 @@ export default class Mills extends API {
    * @returns The generated FileIndex object
    */
   async run(name: string, options: KeyValue, payload: any, headers: KeyValue): Promise<FileIndex> {
-    // Perhaps this should use a new function dedicated to application/json
-    const response = await this.sendPostMultiPart(
+    let data: any
+    if (payload && name !== '/json' && name !== '/schema') {
+      // Unless explicitly using a json-based mill, assume binary data
+      data = new FormData()
+      data.append('file', payload, payload.name || 'milled')
+    } else if (payload) {
+      // Otherwise, assume JSON data
+      data = JSON.stringify(payload)
+    }
+    const response = await this.sendPost(
       `mills${name}`,
       [],
       options,
-      payload,
-      headers
+      data,
+      headers,
+      true // Don't strinify on the other end
     )
     return response.json()
   }

--- a/src/modules/threads.ts
+++ b/src/modules/threads.ts
@@ -54,7 +54,7 @@ export default class Threads extends API {
     // Attempt to create the schema on the fly
     if (schema && typeof schema === 'object') {
       const fileIndex = await this.schemas.add(schema)
-      targetSchema = fileIndex.key
+      targetSchema = fileIndex.hash
     } else if (schema && typeof schema === 'string') {
       // check if it is one of the default schemas
       const known = await this.schemas.defaultByName(schema)

--- a/yarn.lock
+++ b/yarn.lock
@@ -86,7 +86,7 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4":
+"@babel/parser@^7.0.0", "@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.4.4.tgz#5977129431b8fe33471730d255ce8654ae1250b6"
   integrity sha512-5pCS4mOsL+ANsFZGdvNLybx4wtqAZJ0MJjMHxvzI3bvIsz6sQvzW8XX92EYIkiPtIvcfG3Aj+Ir5VNyjnZhP7w==
@@ -98,6 +98,14 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0"
 
+"@babel/runtime@7.0.0-beta.54":
+  version "7.0.0-beta.54"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.0.0-beta.54.tgz#39ebb42723fe7ca4b3e1b00e967e80138d47cadf"
+  integrity sha1-Oeu0JyP+fKSz4bAOln6AE41Hyt8=
+  dependencies:
+    core-js "^2.5.7"
+    regenerator-runtime "^0.12.0"
+
 "@babel/template@^7.1.0", "@babel/template@^7.4.0", "@babel/template@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.4.4.tgz#f4b88d1225689a08f5bc3a17483545be9e4ed237"
@@ -107,7 +115,7 @@
     "@babel/parser" "^7.4.4"
     "@babel/types" "^7.4.4"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4":
+"@babel/traverse@^7.0.0", "@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.4.4.tgz#0776f038f6d78361860b6823887d4f3937133fe8"
   integrity sha512-Gw6qqkw/e6AGzlyj9KnkabJX7VcubqPtkUQVAwkc0wUMldr3A/hezNB3Rc5eIvId95iSGkGIOe5hh1kMKf951A==
@@ -285,6 +293,36 @@
     "@types/istanbul-reports" "^1.1.1"
     "@types/yargs" "^12.0.9"
 
+"@octetstream/eslint-config@3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@octetstream/eslint-config/-/eslint-config-3.0.0.tgz#3239f94790a04e92948f04b0c317bbfffc38b586"
+  integrity sha512-VX8gZ6h9PNKrWb+N9AoWM2DA+eVBAqAL0OLHwLjh+iwLrICQRFYzJDxxHIpD7rN413PCppr2vp6cy8UGdZGd+A==
+  dependencies:
+    babel-eslint "^9.0.0"
+    eslint-config-airbnb-base "^13.1.0"
+    eslint-plugin-import "^2.14.0"
+    eslint-plugin-promise "^4.0.0"
+
+"@octetstream/invariant@1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@octetstream/invariant/-/invariant-1.2.0.tgz#731ae22545a13093f834a6166d4c3fcf505e0abe"
+  integrity sha512-H8dGu44EiXMOU6dv82RiEtLPzi/Q0nmjuPsyznL6VN3KSWEdZI7be2sUO1m7HlWkgD/qSSwt076hBkCgOl9jgw==
+  dependencies:
+    sprintf-js "1.1.2"
+
+"@octetstream/promisify@2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@octetstream/promisify/-/promisify-2.0.2.tgz#29ac3bd7aefba646db670227f895d812c1a19615"
+  integrity sha512-7XHoRB61hxsz8lBQrjC1tq/3OEIgpvGWg6DKAdwi7WRzruwkmsdwmOoUXbU4Dtd4RSOMDwed0SkP3y8UlMt1Bg==
+
+"@softwareventures/fetch-ponyfill-preconfigured@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@softwareventures/fetch-ponyfill-preconfigured/-/fetch-ponyfill-preconfigured-1.1.0.tgz#1a4ee9a2d3ca9d4d812ebb5f99b69b8b855f3ab9"
+  integrity sha512-Q/yHK1axTxiLKWvZnOLRXkCmeqZ6Qs6aO3cXOI2ViAzjeaBiLL4oh251jzvhgSeHyPCWeH70JAmRkHW0mYRraA==
+  dependencies:
+    fetch-ponyfill "^6.0.2"
+    promise-ponyfill "^1.1.0"
+
 "@textile/tslint-rules@1.0.3":
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/@textile/tslint-rules/-/tslint-rules-1.0.3.tgz#18d311d50557cfd7782f0aea539e2f4f8ed0fec3"
@@ -356,11 +394,6 @@
   resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.12.3.tgz#b672cfaac25cbbc634a0fd92c515f66faa18dbca"
   integrity sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==
 
-"@types/isomorphic-fetch@^0.0.35":
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/@types/isomorphic-fetch/-/isomorphic-fetch-0.0.35.tgz#c1c0d402daac324582b6186b91f8905340ea3361"
-  integrity sha512-DaZNUvLDCAnCTjgwxgiL1eQdxIKEpNLOlTNtAgnZc50bG2copGhRrFN9/PxPBuJe+tZVLCbQ7ls0xveXVRPkvw==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
@@ -419,6 +452,16 @@
   version "12.0.0"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.0.0.tgz#d11813b9c0ff8aaca29f04cbc12817f4c7d656e5"
   integrity sha512-Jrb/x3HT4PTJp6a4avhmJCDEVrPdqLfl3e8GGMbpkGGdwAV5UGlIs4vVEfsHHfylZVOKZWpOqmqFH8CbfOZ6kg==
+
+"@types/promise-polyfill@^6.0.1":
+  version "6.0.3"
+  resolved "https://registry.yarnpkg.com/@types/promise-polyfill/-/promise-polyfill-6.0.3.tgz#e2f38fcd244a9e0df2cc7528e0711abcbc707b5e"
+  integrity sha512-f/BFgF9a+cgsMseC7rpv9+9TAE3YNjhfYrtwCo/pIeCDDfQtE6PY0b5bao2eIIEpZCBUy8Y5ToXd4ObjPSJuFw==
+
+"@types/setasap@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/setasap/-/setasap-2.0.0.tgz#169ed97dc9ae707670e68d2d46400c3df1f7c898"
+  integrity sha512-nbaj9OJdCiJUM2daJPWO+lgcrp4wR4ZPhwA7s/8+9YstW3/TzMJ4v1tY5RaNUZeOUfAmVXEoXXqsEsQxZ/Zdvw==
 
 "@types/shelljs@^0.8.0":
   version "0.8.5"
@@ -956,6 +999,18 @@ babel-code-frame@^6.22.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
+
+babel-eslint@^9.0.0:
+  version "9.0.0"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-9.0.0.tgz#7d9445f81ed9f60aff38115f838970df9f2b6220"
+  integrity sha512-itv1MwE3TMbY0QtNfeL7wzak1mV47Uy+n6HtSOO4Xd7rvmO+tsGQSgyOEEgo6Y2vHZKZphaoelNeSVj4vkLA1g==
+  dependencies:
+    "@babel/code-frame" "^7.0.0"
+    "@babel/parser" "^7.0.0"
+    "@babel/traverse" "^7.0.0"
+    "@babel/types" "^7.0.0"
+    eslint-scope "3.7.1"
+    eslint-visitor-keys "^1.0.0"
 
 babel-jest@^24.8.0:
   version "24.8.0"
@@ -1664,7 +1719,7 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
-core-js@^2.4.0:
+core-js@^2.4.0, core-js@^2.5.7:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
@@ -2257,7 +2312,7 @@ eslint-plugin-filenames@^1.1.0:
     lodash.snakecase "4.1.1"
     lodash.upperfirst "4.3.1"
 
-eslint-plugin-import@^2.16.0:
+eslint-plugin-import@^2.14.0, eslint-plugin-import@^2.16.0:
   version "2.17.2"
   resolved "https://registry.yarnpkg.com/eslint-plugin-import/-/eslint-plugin-import-2.17.2.tgz#d227d5c6dc67eca71eb590d2bb62fb38d86e9fcb"
   integrity sha512-m+cSVxM7oLsIpmwNn2WXTJoReOF9f/CtLMo7qOVmKd1KntBy0hEcuNZ3erTmWjx+DxRO0Zcrm5KwAvI9wHcV5g==
@@ -2293,10 +2348,23 @@ eslint-plugin-prettier@^3.0.1:
   dependencies:
     prettier-linter-helpers "^1.0.0"
 
+eslint-plugin-promise@^4.0.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-promise/-/eslint-plugin-promise-4.1.1.tgz#1e08cb68b5b2cd8839f8d5864c796f56d82746db"
+  integrity sha512-faAHw7uzlNPy7b45J1guyjazw28M+7gJokKUjC5JSFoYfUEyy6Gw/i7YQvmv2Yk00sUjWcmzXQLpU1Ki/C2IZQ==
+
 eslint-restricted-globals@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/eslint-restricted-globals/-/eslint-restricted-globals-0.1.1.tgz#35f0d5cbc64c2e3ed62e93b4b1a7af05ba7ed4d7"
   integrity sha1-NfDVy8ZMLj7WLpO0saevBbp+1Nc=
+
+eslint-scope@3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
+  integrity sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
 
 eslint-scope@^3.7.1:
   version "3.7.3"
@@ -2710,6 +2778,13 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "^2.0.0"
 
+fetch-ponyfill@^6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/fetch-ponyfill/-/fetch-ponyfill-6.0.2.tgz#bc2d92afd0140e39518beccd2fd0682ab4491cb6"
+  integrity sha512-hBWVb6Z0chjr9r0g4N5uknldAnyFstWTnX6oFxMsL9ZlSL7fa66Keis3y4SCMgpTggY4GeGbB4z3z5g5SmrgkQ==
+  dependencies:
+    node-fetch "~2.1.0"
+
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -2860,7 +2935,7 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@~2.3.2:
+form-data@^2.3.2, form-data@~2.3.2:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
   integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
@@ -2877,6 +2952,17 @@ format-people@^0.1.4:
     extend-shallow "^2.0.1"
     markdown-utils "^0.7.3"
     right-pad-values "^0.3.1"
+
+formdata-node@^1.5.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/formdata-node/-/formdata-node-1.5.2.tgz#6450771c2c1dd6ba1ed4f7303a2564b0c8730db1"
+  integrity sha512-tmXmPazQ+nl6XV6KQmnXshwq1oDAF/Vgs1Ig/k4QZiJWHWhv9V9DVJqFKs4Iu5BZRxXyVqjBxzc1l/2xYPGB6g==
+  dependencies:
+    "@babel/runtime" "7.0.0-beta.54"
+    "@octetstream/invariant" "1.2.0"
+    mime-types "2.1.22"
+    nanoid "2.0.1"
+    promise-fs "2.1.0"
 
 forwarded@~0.1.2:
   version "0.1.2"
@@ -3859,6 +3945,13 @@ isomorphic-fetch@^2.2.1:
   dependencies:
     node-fetch "^1.0.1"
     whatwg-fetch ">=0.10.0"
+
+isomorphic-form-data@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-form-data/-/isomorphic-form-data-2.0.0.tgz#9f6adf1c4c61ae3aefd8f110ab60fb9b143d6cec"
+  integrity sha512-TYgVnXWeESVmQSg4GLVbalmQ+B4NPi/H4eWxqALKj63KsUrcu301YDjBqaOw3h+cbak7Na4Xyps3BiptHtxTfg==
+  dependencies:
+    form-data "^2.3.2"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -4893,6 +4986,18 @@ mime-db@1.40.0, "mime-db@>= 1.40.0 < 2":
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.40.0.tgz#a65057e998db090f732a68f6c276d387d4126c32"
   integrity sha512-jYdeOMPy9vnxEqFRRo6ZvTZ8d9oPb+k18PKoYNYUe2stVEBPPwsln/qWzdbmaIvnhZ9v2P+CuecK+fpUfsV2mA==
 
+mime-db@~1.38.0:
+  version "1.38.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.38.0.tgz#1a2aab16da9eb167b49c6e4df2d9c68d63d8e2ad"
+  integrity sha512-bqVioMFFzc2awcdJZIzR3HjZFX20QhilVS7hytkKrv7xFAn8bM1gzc/FOX2awLISvWe0PV8ptFKcon+wZ5qYkg==
+
+mime-types@2.1.22:
+  version "2.1.22"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.22.tgz#fe6b355a190926ab7698c9a0556a11199b2199bd"
+  integrity sha512-aGl6TZGnhm/li6F7yx82bJiBZwgiEa4Hf6CNr8YO+r5UHr53tSTYZb102zyU50DOWWKeOv0uQLRL0/9EiKWCog==
+  dependencies:
+    mime-db "~1.38.0"
+
 mime-types@^2.1.12, mime-types@~2.1.17, mime-types@~2.1.19, mime-types@~2.1.24:
   version "2.1.24"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.24.tgz#b6f8d0b3e951efb77dedeca194cff6d16f676f81"
@@ -5048,6 +5153,11 @@ nan@^2.12.1:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.13.2.tgz#f51dc7ae66ba7d5d55e1e6d4d8092e802c9aefe7"
   integrity sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==
 
+nanoid@2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-2.0.1.tgz#deb55cac196e3f138071911dabbc3726eb048864"
+  integrity sha512-k1u2uemjIGsn25zmujKnotgniC/gxQ9sdegdezeDiKdkDW56THUMqlz3urndKCXJxA6yPzSZbXx/QCMe/pxqsA==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -5121,6 +5231,11 @@ node-fetch@^1.0.1:
   dependencies:
     encoding "^0.1.11"
     is-stream "^1.0.1"
+
+node-fetch@~2.1.0:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
+  integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -5850,10 +5965,33 @@ progress@^2.0.0:
   resolved "https://registry.yarnpkg.com/progress/-/progress-2.0.3.tgz#7e8cf8d8f5b8f239c1bc68beb4eb78567d572ef8"
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
+promise-fs@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/promise-fs/-/promise-fs-2.1.0.tgz#497f7c7143e4ca9d418ab1f6ba76fe30a06cde24"
+  integrity sha512-Wl6Y+dSQnw1cJjXdMbXABoH2fRXC3G3KjQHH32qPT6UYyDrh9Iouj/rvI+KKJiVFwQ1/3KiPe1dybp6cHYvUag==
+  dependencies:
+    "@octetstream/eslint-config" "3.0.0"
+    "@octetstream/promisify" "2.0.2"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
+promise-polyfill@^8.1.0:
+  version "8.1.0"
+  resolved "https://registry.yarnpkg.com/promise-polyfill/-/promise-polyfill-8.1.0.tgz#30059da54d1358ce905ac581f287e184aedf995d"
+  integrity sha512-OzSf6gcCUQ01byV4BgwyUCswlaQQ6gzXc23aLQWhicvfX9kfsUiUhgt3CCQej8jDnl8/PhGF31JdHX2/MzF3WA==
+
+promise-ponyfill@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/promise-ponyfill/-/promise-ponyfill-1.1.0.tgz#dcd52dc62eb28861330a6b9c2b76db0aabfb8931"
+  integrity sha512-+N8mpWIo2xqo7t5ZpqFAEsPc51EM9oBDb0gL+k0lx+OPj4+y+pIlL74jaAgqyhvgKluedbtnRO8gg0TJLkFNfQ==
+  dependencies:
+    "@types/promise-polyfill" "^6.0.1"
+    "@types/setasap" "^2.0.0"
+    promise-polyfill "^8.1.0"
+    setasap "^2.0.1"
 
 promise@^7.1.1:
   version "7.3.1"
@@ -6117,6 +6255,11 @@ regenerator-runtime@^0.11.0:
   version "0.11.1"
   resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz#be05ad7f9bf7d22e056f9726cee5017fbf19e2e9"
   integrity sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==
+
+regenerator-runtime@^0.12.0:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/regenerator-runtime/-/regenerator-runtime-0.12.1.tgz#fa1a71544764c036f8c49b13a08b2594c9f8a0de"
+  integrity sha512-odxIc1/vDlo4iZcfXqRYFj0vpXFNoGdKMAUieAlFYO6m/nl5e9KR/beGf41z4a1FI+aQgtjhuaSlDxQ0hmkrHg==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -6544,6 +6687,11 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
+setasap@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/setasap/-/setasap-2.0.1.tgz#affba1a2841ba9a0825f652ea5cbe6ce88a4cef4"
+  integrity sha512-DsoqaT3/BB0FTXi8DGMoJse2SGYkUTkOQaCjBx/DJSodGN2EE/rHU9CyJ7H1mYGMyzJvwUlgJQTI4twRg5QY3g==
+
 setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
@@ -6777,6 +6925,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
+  integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==
 
 sprintf-js@~1.0.2:
   version "1.0.3"


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>

In doing this update, I've simplified the `files.add` API, so that `FormData` is no longer required as input for binary data by the end user (they can just use pretty much any object, and the FormData wrapping happens behind the scenes). I've also switched to using a fetch ponyfill rather than a polyfill to avoid polluting the global name-space. This also includes some internal simplifications, plus returns blob data from `file.content`, which is what the REST API is returning.

I think after this is merged, we can do a 1.0.0 release and start doing semantic versioning properly?