### PR TITLE
More consistent use of `block.ignore`

### DIFF
--- a/src/modules/blocks.ts
+++ b/src/modules/blocks.ts
@@ -60,13 +60,13 @@ export default class Blocks extends API {
   }
 
   /**
-   * Remove a thread block by ID
+   * Ignores a block by its ID
    *
    * @param id ID of the block
-   * @returns Whether or not the operation was successful
+   * @returns The added ignore block
    */
-  async remove(id: string) {
+  async ignore(id: string) {
     const response = await this.sendDelete(`blocks/${id}`)
-    return response.status === 204
+    return response.json() as Promise<Block>
   }
 }

--- a/src/modules/files.ts
+++ b/src/modules/files.ts
@@ -1,5 +1,5 @@
 import { API, DEFAULT_API_OPTIONS } from '../core/api'
-import { ApiOptions, Node, FilesList, Files as FilesType, Keys, DirectoryList } from '../models'
+import { ApiOptions, Node, FilesList, Files as FilesType, Keys, DirectoryList, Block } from '../models'
 import SchemaMiller, { MillOpts } from '../helpers/schema-miller'
 import Mills from './mills'
 import Threads from './threads'
@@ -67,11 +67,11 @@ export default class Files extends API {
    * Ignored blocks are by default not returned when listing.
    *
    * @param id ID of the thread file
-   * @returns Whether or not the operation was successfull
+   * @returns The added ignore block
    */
   async ignore(id: string) {
     const response = await this.sendDelete(`blocks/${id}`)
-    return response.status === 204
+    return response.json() as Promise<Block>
   }
 
   /**


### PR DESCRIPTION
Signed-off-by: Carson Farmer <carson.farmer@gmail.com>
This also renames it from `remove` to `ignore` which is more in line with other APIs and more accurate in terms of what is actually happening (UIs can still call it deleting or whatever).