### PR TITLE
support TextDecoder in older nodejs env

### DIFF
--- a/src/helpers/__test__/handlers.test.ts
+++ b/src/helpers/__test__/handlers.test.ts
@@ -1,0 +1,28 @@
+import { streamHandler } from '../handlers'
+import { ReadableStream } from 'web-streams-polyfill/ponyfill'
+import { TextEncoder } from 'util'
+
+describe('streamHandler', () => {
+  const mockStream = new ReadableStream<ArrayBuffer>()
+  const mockRead = jest.fn()
+
+  mockStream.getReader = jest.fn().mockReturnValue({
+    read: mockRead
+  })
+  const encoder = new TextEncoder()
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it('backward compatible with nodejs <= 11', async () => {
+    // the test should pass in ci with older/new nodejs versions
+    expect.assertions(1)
+    const data = {data: 'can you see me?'}
+    mockRead
+      .mockResolvedValueOnce({ done: false, value: encoder.encode(JSON.stringify(data)) })
+      .mockResolvedValueOnce({ done: true })
+    const result = await streamHandler(mockStream).getReader().read()
+    expect(result.value).toEqual(data)
+  })
+})

--- a/src/helpers/handlers.ts
+++ b/src/helpers/handlers.ts
@@ -1,6 +1,12 @@
 import { Readable } from 'stream'
 import { ReadableStream } from 'web-streams-polyfill/ponyfill'
 
+// polyfill TextDecoder to be backward compatible with older
+// nodejs that doesn't expose TextDecoder as a global variable
+if (typeof TextDecoder === 'undefined' && typeof require !== 'undefined') {
+  (global as any).TextDecoder  = require('util').TextDecoder
+}
+
 // https://github.com/gwicke/node-web-streams
 export const readableNodeToWeb = <T>(nodeStream: Readable | ReadableStream<T>) => {
   if (!(nodeStream instanceof Readable)) {


### PR DESCRIPTION
fixing #118 

- added a simple check for global TextDecoder, if not available, fallback to node 'util' package.
- added test for helper

tested it with both node 10.15.1 and 12.3.1

p.s. this is my first contribution to your wonderful work, please let me know if I missed anything.