### PR TITLE
Pull over pb updates from go-textile

### DIFF
--- a/src/models/model_pb.ts
+++ b/src/models/model_pb.ts
@@ -48,7 +48,7 @@ export interface Thread {
   whitelist: string[]
   state: Thread.State
   head: string
-  head_block: Block
+  head_blocks: Block[]
   schema_node: Node
   block_count: number
   peer_count: number


### PR DESCRIPTION
Now properly treats multiple heads as head_blocks: Block[] rather than head_block: Block
Fixes #134 