### PR TITLE
js-http-client: add raw ipfs pubsub pub and sub from go-textile v0.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "@ef-carbon/fetch": "^2.1.3",
     "@ef-carbon/url": "^2.4.3",
+    "@therebel/ksuid": "^1.1.2-alpha1",
     "isomorphic-form-data": "^2.0.0",
     "toposort": "^2.0.2",
     "url-parse": "^1.4.4",

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -176,6 +176,25 @@ class API {
     })
     return handleErrors(response)
   }
+
+  /**
+   * Make an EventSource request to the Textile node
+   *
+   * @param url The relative URL of the API endpoint
+   * @param args An array of arguments to pass as query in native EventSource or Textile args headers in EventSourcePolyfill
+   * @param opts An object of options to pass as Textile options headers
+   */
+  protected sendEventSource(url: string, args?: string[], opts?: KeyValue, headers?: KeyValue) {
+    // native EventSource can't set header, but can CORS
+    return new EventSource(buildAbsoluteURL(this.baseURL, `${url}${opts ? `?${URL.qs.stringify(opts)}` : ''}`))
+
+    // EventSourcePolyfill of eventsource@1.0.7 can set header, but can't CORS
+    // return new EventSourcePolyfill(buildAbsoluteURL(this.baseURL, url), {
+    //     headers: {
+    //         'X-Textile-Opts': getOpts(opts),
+    //     }
+    // });
+  }
 }
 
 export { API }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import Cafes from './modules/cafes'
 import Config from './modules/config'
 import Comments from './modules/comments'
 import Contacts from './modules/contacts'
+import Events from './modules/events'
 import Feed from './modules/feed'
 import File from './modules/file'
 import Files from './modules/files'
@@ -47,6 +48,8 @@ export class Textile {
   comments: Comments
   /** @property {Contacts} contacts - Manage Textile peer Contacts */
   contacts: Contacts
+  /** @property {Events} events - Manage the Textile Events */
+  events: Events
   /** @property {Feed} feed - Manage the Textile Feed */
   feed: Feed
   /** @property {File} file - Manage a Textile File */
@@ -94,6 +97,7 @@ export class Textile {
     this.config = new Config(_options)
     this.comments = new Comments(_options)
     this.contacts = new Contacts(_options)
+    this.events = new Events(_options)
     this.feed = new Feed(_options)
     this.file = new File(_options)
     this.files = new Files(_options)

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ export * from './message_pb'
 export * from './query_pb'
 export * from './threads_service_pb'
 export * from './view_pb'
+export * from './mobile_pb'
 
 /**
  * The options object for the client object

--- a/src/modules/events.ts
+++ b/src/modules/events.ts
@@ -1,0 +1,213 @@
+import { API, DEFAULT_API_OPTIONS } from '../core/api'
+import { ApiOptions, MobileQueryEvent } from '../models'
+import { ReadableStream } from 'web-streams-polyfill/ponyfill'
+
+class EventSubscription {
+  cancel: () => void
+  constructor(cancel: () => void) {
+    this.cancel = cancel
+  }
+}
+
+/**
+ * Events is an API to stream updates from an ipfs pubsub
+ */
+export default class Events extends API {
+  private pubsubQueryResultListeners: Array<{
+    listener: (queryId: string, message: string, messageId: string) => void,
+    queryId: string
+  }>
+  private queryDoneListeners: Array<{
+    listener: (queryId: string) => void,
+    queryId: string
+  }>
+  private queryErrorListeners: Array<{
+    listener: (queryId: string, error: string) => void,
+    queryId: string
+  }>
+  constructor(opts: ApiOptions = DEFAULT_API_OPTIONS) {
+    super(opts)
+    this.pubsubQueryResultListeners = []
+    this.queryDoneListeners = []
+    this.queryErrorListeners = []
+  }
+
+  addPubsubQueryResultListener(
+    listener: (queryId: string, message: string, messageId: string) => void,
+    queryId: string,
+    queryHandle: EventSource | ReadableStream<ArrayBuffer>
+  ) {
+    this.pubsubQueryResultListeners.push({
+      listener,
+      queryId
+    })
+    // For cancellation
+    const isEventSubscription = new EventSubscription(
+      () => {
+        this.pubsubQueryResultListeners = this.pubsubQueryResultListeners.filter(
+          (item) => item.queryId !== queryId
+        )
+        this.queryDoneListeners = this.queryDoneListeners.filter(
+          (item) => item.queryId !== queryId
+        )
+        this.queryErrorListeners = this.queryErrorListeners.filter(
+          (item) => item.queryId !== queryId
+        )
+        if (queryHandle instanceof EventSource) {
+          queryHandle.close()
+        }
+      }
+    )
+
+    const onPubsubQueryEvent = (queryEvent: MobileQueryEvent) => {
+      const message = queryEvent.data.value.values[0]
+      const messageId = queryEvent.data.id
+      for (const item of this.pubsubQueryResultListeners) {
+        if (item.queryId === queryEvent.id) {
+          item.listener(queryEvent.id, message, messageId)
+        }
+      }
+    }
+
+    const onQueryError = (e: Error) => {
+      for (const item of this.queryErrorListeners) {
+        if (item.queryId === queryId) {
+          item.listener(queryId, e.toString())
+        }
+      }
+    }
+
+    const onQueryDone = () => {
+      for (const item of this.queryDoneListeners) {
+        if (item.queryId === queryId) {
+          item.listener(queryId)
+        }
+      }
+
+      this.pubsubQueryResultListeners = this.pubsubQueryResultListeners.filter(
+        (item) => item.queryId !== queryId
+      )
+      this.queryDoneListeners = this.queryDoneListeners.filter(
+        (item) => item.queryId !== queryId
+      )
+      this.queryErrorListeners = this.queryErrorListeners.filter(
+        (item) => item.queryId !== queryId
+      )
+    }
+
+    if (queryHandle instanceof EventSource) {
+      queryHandle.addEventListener('update', (e: any) => {
+        try {
+          const queryEvent: MobileQueryEvent = JSON.parse(e.data)
+          onPubsubQueryEvent(queryEvent)
+        } catch (e) {
+          onQueryError(e)
+        }
+      }, false)
+      queryHandle.addEventListener('open', (e: any) => {
+        // Connection was opened.
+      }, false)
+      queryHandle.addEventListener('error', (e: any) => {
+        if (e.readyState === 2 /* EventSource.CLOSED */) {
+          onQueryDone()
+        } else {
+          onQueryError(e)
+        }
+      }, false)
+      return isEventSubscription
+    } else {
+      // For cancellation
+      let isReader: any
+      let cancellationRequest = false
+      return new ReadableStream<ArrayBuffer>({
+        start(controller) {
+          const reader = queryHandle.getReader()
+          isReader = reader
+          const decoder = new TextDecoder()
+          let dataBuffer = ''
+
+          const processResult = (result: ReadableStreamReadResult<ArrayBuffer>) => {
+            if (result.done) {
+              if (cancellationRequest) {
+                onQueryDone()
+                return // Immediately exit
+              }
+              dataBuffer = dataBuffer.trim()
+              if (dataBuffer.length !== 0) {
+                try {
+                  const queryEvent: MobileQueryEvent = JSON.parse(dataBuffer)
+                  onPubsubQueryEvent(queryEvent)
+                } catch (e) {
+                  controller.error(e)
+                }
+              }
+              onQueryDone()
+              controller.close()
+              return
+            }
+            const data = decoder.decode(result.value, { stream: true })
+            dataBuffer += data
+            const lines = dataBuffer.split('\n')
+            for (const line of lines) {
+              const l = line.trim()
+              if (l.length > 0) {
+                try {
+                  const queryEvent: MobileQueryEvent = JSON.parse(l)
+                  onPubsubQueryEvent(queryEvent)
+                } catch (e) {
+                  onQueryError(e)
+                  controller.error(e)
+                  break
+                }
+              }
+            }
+            dataBuffer = lines.length > 1 ? lines[lines.length - 1] : ''
+            reader.read().then(processResult)
+          }
+          reader.read().then(processResult)
+        },
+        cancel(reason?: string) {
+          isEventSubscription.cancel()
+          cancellationRequest = true
+          isReader.cancel(reason)
+        }
+      })
+    }
+  }
+
+  addQueryDoneListener(
+    listener: (queryId: string) => void,
+    queryId: string
+  ) {
+    this.queryDoneListeners.push({
+      listener,
+      queryId
+    })
+    // For cancellation
+    const isEventSubscription = new EventSubscription(
+      () =>
+        (this.queryDoneListeners = this.queryDoneListeners.filter(
+          (item) => item.queryId !== queryId
+        ))
+    )
+    return isEventSubscription
+  }
+
+  addQueryErrorListener(
+    listener: (queryId: string, error: string) => void,
+    queryId: string
+  ) {
+    this.queryErrorListeners.push({
+      listener,
+      queryId
+    })
+    // For cancellation
+    const isEventSubscription = new EventSubscription(
+      () =>
+        (this.queryErrorListeners = this.queryErrorListeners.filter(
+          (item) => item.queryId !== queryId
+        ))
+    )
+    return isEventSubscription
+  }
+}

--- a/src/modules/ipfs.ts
+++ b/src/modules/ipfs.ts
@@ -1,4 +1,8 @@
 import { API } from '../core/api'
+import { readableNodeToWeb } from '../helpers/handlers'
+import { MobileQueryEvent } from '../models'
+import { ReadableStream } from 'web-streams-polyfill/ponyfill'
+import KSUID from '@therebel/ksuid'
 
 /**
  * IPFS is an API module for working with an underlying IPFS peer
@@ -58,5 +62,48 @@ export default class IPFS extends API {
   async connect(addr: string) {
     const response = await this.sendPost(`ipfs/swarm/connect`, [addr])
     return response.status === 200
+  }
+
+  /**
+   * Publishes a message to a given pubsub topic
+   *
+   * @param topic The topic to publish to
+   * @param data The payload of message to publish
+   * @returns Whether the publish was successfull
+   */
+  async pubsubPub(topic: string, data: string | object) {
+    const response = await this.sendPost(`ipfs/pubsub/pub/${topic}`, undefined, undefined, data, undefined, typeof data === 'string')
+    return response.status === 200
+  }
+
+  /**
+   * Subscribes to messages on a given topic with GET
+   *
+   * @param topic The ipfs pubsub sub topic
+   * @returns A ReadableStream of ArrayBuffer
+   */
+  async pubsubSubGet(topic: string, queryId: string) {
+    const response = await this.sendGet(`ipfs/pubsub/sub/${topic}`, undefined, { queryId })
+    if (!response.body) {
+      throw Error('Empty response stream')
+    }
+    return readableNodeToWeb<ArrayBuffer>(response.body as ReadableStream)
+  }
+
+  /**
+   * Subscribes to messages on a given topic with EventSource or GET
+   *
+   * @param topic The ipfs pubsub sub topic
+   * @param useEventSource Whether to use EventSource or GET
+   * @returns An object with queryId and EventSource or a ReadableStream of ArrayBuffer
+   */
+  async pubsubSub(topic: string, useEventSource?: boolean) {
+    const ksuidFromAsync = await KSUID.random()
+    const queryId = ksuidFromAsync.string
+    const queryHandle = useEventSource ? this.sendEventSource(`ipfs/pubsub/sub/${topic}`, undefined, { events: true, queryId }) : await this.pubsubSubGet(topic, queryId)
+    return {
+      queryId,
+      queryHandle
+    }
   }
 }


### PR DESCRIPTION
 Add raw ipfs pubsub pub and sub to [Expose simple p2p direct message API](https://github.com/textileio/go-textile/issues/885)

For easy PR review, there is no latest docs in this PR

Need PR [ipfs: add raw pubsub pub and sub to api and cmd and mobile](https://github.com/textileio/go-textile/pull/940) and set go-textile to v0.7.6 first